### PR TITLE
Configure Pyright venv for Neovim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ ignore = [
 ]
 
 [tool.pyright]
+venvPath = "."
 venv = ".venv"
 typeCheckingMode = "strict"
 


### PR DESCRIPTION
This fixes the issue where Neovim's Pyright integration complains about missing stubs for pandas. Now the correct venv is looked up for declarations and definitions.